### PR TITLE
Rainbows in greyscale, rgb-spectrum, and cubehelix now available

### DIFF
--- a/examples/rainbow_fluid.rb
+++ b/examples/rainbow_fluid.rb
@@ -1,0 +1,243 @@
+require "graphics"
+require "graphics/rainbows"
+
+class Float
+  ##
+  # A floating-point friendly `between?` function that excludes
+  # the lower bound.
+  # Equivalent to `min < x <= max`
+  ##
+  def xbetween? min, max
+    min < self && self <= max
+  end
+end
+
+class Particle
+  attr_accessor :density, :position, :velocity,
+                :pressure_force, :viscosity_force
+  def initialize pos
+    # Scalars
+    @density = 0
+
+    # Forces
+    @position        = pos
+    @velocity        = V::ZERO
+    @pressure_force  = V::ZERO
+    @viscosity_force = V::ZERO
+  end
+end
+
+class SPH
+  ##
+  # Constants
+  #
+
+  MASS          = 5  # Particle mass
+  DENSITY       = 1  # Rest density
+  GRAVITY       = V[0, -0.5]
+  H             = 1  # Smoothing cutoff- essentially, particle size
+  K             = 20 # Temperature constant- higher means particle repel more strongly
+  ETA           = 1  # Viscosity constant- higher for more viscous
+
+  attr_reader :particles
+
+  def initialize
+    # Instantiate particles!
+    @particles = []
+    (0..10).each do |x|
+      (0..10).each do |y|
+        jitter = rand * 0.1
+        particles << Particle.new(V[x+1+jitter, y+5])
+      end
+    end
+  end
+
+  ##
+  # A weighting function (kernel) for the contribution of each neighbor
+  # to a particle's density. Forms a nice smooth gradient from the center
+  # of a particle to H, where it's 0
+  #
+
+  def weight r, h
+    len_r = r.magnitude
+
+    if len_r.xbetween? 0, h
+      315.0 / (64 * Math::PI * h**9) * (h**2 - len_r**2)**3
+    else
+      0.0
+    end
+  end
+
+  ##
+  # Gradient ( that is, V(dx, dy) ) of a weighting function for
+  # a particle's pressure. This weight function is spiky (not flat or
+  # smooth at x=0) so particles close together repel strongly.
+  #
+
+  def gradient_weight_spiky r, h
+    len_r = r.magnitude
+
+    if len_r.xbetween? 0, h
+      r * (45.0 / (Math::PI * h**6 * len_r)) * (h - len_r)**2 * (-1.0)
+    else
+      V::ZERO
+    end
+  end
+
+  ##
+  # The laplacian of a weighting function that tends towards infinity when
+  # approching 0 (slows down particles moving faster than their neighbors)
+  #
+
+  def laplacian_weight_viscosity r, h
+    len_r = r.magnitude
+
+    if len_r.xbetween? 0, h
+      45.0 / (2 * Math::PI * h**5) * (1 - len_r / h)
+    else
+      0.0
+    end
+  end
+
+  def clear
+    # Clear everything
+    particles.each do |particle|
+      particle.density = DENSITY
+      particle.pressure_force = V::ZERO
+      particle.viscosity_force = V::ZERO
+    end
+  end
+
+  def calculate_density
+    # Calculate fluid density around each particle
+    particles.each do |particle|
+      particles.each do |neighbor|
+        # If particles are close together, density increases
+        distance = particle.position - neighbor.position
+
+        if distance.magnitude < H then
+          # Particles are close enough to matter
+          particle.density += MASS * weight(distance, H)
+        end
+      end
+    end
+  end
+
+  def calculate_forces
+    # Calculate forces on each particle based on density
+    particles.each do |particle|
+      particles.each do |neighbor|
+        distance = particle.position - neighbor.position
+        if  distance.magnitude <= H then
+          # Temporary terms used to caclulate forces
+          density_p = particle.density
+          density_n = neighbor.density
+
+          # This *should* never happen, but it's good to check,
+          # because we're dividing by density later
+          raise "Particle density is, impossibly, 0" unless density_n != 0
+
+          # Pressure derived from the ideal gas law (constant temp)
+          pressure_p = K * (density_p - DENSITY)
+          pressure_n = K * (density_n - DENSITY)
+
+          # Navier-Stokes equations for pressure and viscosity
+          # (ignoring surface tension)
+          particle.pressure_force += gradient_weight_spiky(distance, H) *
+            (-1.0 * MASS * (pressure_p + pressure_n) / (2 * density_n))
+
+          particle.viscosity_force +=
+            (neighbor.velocity - particle.velocity) *
+            (ETA * MASS * (1/density_n) * laplacian_weight_viscosity(distance, H))
+        end
+      end
+    end
+  end
+
+  def apply_forces delta_time
+    # Apply forces to particles- make them move!
+    particles.each do |particle|
+      total_force = particle.pressure_force + particle.viscosity_force
+
+      # 'Eulerian' style momentum:
+
+      # Calculate acceleration from forces
+      acceleration = (total_force * (1.0 / particle.density * delta_time)) + GRAVITY
+
+      # Update position and velocity
+      particle.velocity += acceleration * delta_time
+      particle.position += particle.velocity * delta_time
+    end
+  end
+
+  def step delta_time
+    clear
+    calculate_density
+    calculate_forces
+    apply_forces delta_time
+  end
+
+  ##
+  # The walls nudge particles back in-bounds, plus a little jitter
+  # so nothing gets stuck
+  #
+
+  def make_particles_stay_in_bounds scale
+    # TODO: Better boundary conditions (THESE ARE A LAME WORKAROUND)
+    particles.each do |particle|
+      if particle.position.x >= scale - 0.01
+        particle.position.x = scale - (0.01 + 0.1*rand)
+        particle.velocity.x = 0
+      elsif particle.position.x < 0.01
+        particle.position.x = 0.01 + 0.1*rand
+        particle.velocity.x = 0
+      end
+
+      if particle.position.y >= scale - 0.01
+        particle.position.y = scale - (0.01+rand*0.1)
+        particle.velocity.y = 0
+      elsif particle.position.y < 0.01
+        particle.position.y = 0.01 + rand*0.1
+        particle.velocity.y = 0
+      end
+    end
+  end
+end
+
+class SimulationWindow < Graphics::Simulation
+  WINSIZE = 500
+
+  attr_reader :simulation, :s, :spectrum
+
+  DELTA_TIME = 0.1
+
+  def initialize
+    super WINSIZE, WINSIZE, 16, "Smoothed Particle Hydrodynamics"
+    @simulation = SPH.new
+    @scale = 15
+    @s = WINSIZE.div @scale
+    @spectrum = Graphics::Cubehelix.new
+    self.initialize_rainbow spectrum, "cubehelix"
+  end
+
+  def update time
+    simulation.step DELTA_TIME
+    simulation.make_particles_stay_in_bounds @scale
+  end
+
+  def draw time
+    clear
+
+    simulation.particles.each do |particle|
+      pos = particle.position * s
+      color = spectrum.clamp(particle.density*30 + 60, 0, 360).to_i
+
+      # Particles
+      circle(pos.x, pos.y, 5, "cubehelix_#{color}".to_sym, true)
+
+      fps time
+    end
+  end
+end
+
+SimulationWindow.new.run

--- a/lib/graphics/rainbows.rb
+++ b/lib/graphics/rainbows.rb
@@ -1,0 +1,128 @@
+class Graphics::Rainbow
+  attr_reader :cache
+
+  def initialize
+    @cache = self.cache_colors
+  end
+
+  def clamp d, min, max
+    [[min, d].max, max].min
+  end
+
+  ##
+  # Takes a value and a range,
+  # and scales that range to 0-360
+  def scale d, min, max
+    range = max - min
+    if range != 0
+      scaled = (d.to_f / range) * 360
+      return clamp(scaled, 0, 360).round
+    else
+      0
+    end
+  end
+
+  def cache_colors
+    # Saves all the colors to a hash
+    cache = {}
+    (0..360).each do |degree|
+      cache[degree] = _color degree
+    end
+    cache
+  end
+
+  def color d, min=0, max=360
+    scaled = scale d, min, max
+    @cache[scaled]
+  end
+
+  def _color degree
+    raise "Subclass responsibility"
+  end
+  private :_color
+end
+
+##
+# Black to white gradient
+#
+class Graphics::Greyscale < Graphics::Rainbow
+  def initialize
+    super
+  end
+
+  def _color degree
+    brightness_unit = degree/360.0
+    brightness = (brightness_unit*255.0).floor # Scale back to RGB
+
+    [brightness, brightness, brightness]
+  end
+end
+
+##
+# The full RGB spectrum
+#
+class Graphics::Hue < Graphics::Rainbow
+
+  def initialize
+    super
+  end
+
+  def _color degree
+    main_color = 1 * 255 # Let chroma (saturation * brightness) always == 1
+    second_strongest_color = ((1 - (degree/60.0 % 2 - 1).abs) * 255).floor
+
+    case degree
+    when 0..60
+      [main_color, second_strongest_color, 0]
+    when 61..120
+      [second_strongest_color, main_color, 0]
+    when 121..180
+      [0, main_color, second_strongest_color]
+    when 181..240
+      [0, second_strongest_color, main_color]
+    when 241..300
+      [second_strongest_color, 0, main_color]
+    when 301..360
+      [main_color, 0, second_strongest_color]
+    end
+  end
+end
+
+
+##
+# Spectrum with linearly increasing brightness
+#
+class Graphics::Cubehelix < Graphics::Rainbow
+
+  def initialize
+    super
+  end
+
+  def _color degree
+    d = degree/360.0
+    start = 0.5 # Starting position in color space - 0=blue, 1=red, 2=green
+    rotations = -1.5 # How many rotations through the rainbow?
+    saturation = 1.2
+    gamma = 1.0
+    fract = d**gamma # Position on the spectrum
+
+    # Amplitude of the helix
+    amp = saturation * fract * (1 - fract) / 2.0
+    angle = 2*Math::PI*(start/3.0 + 1.0 + rotations*fract)
+    # From the CubeHelix Equations
+    r = fract + amp * (-0.14861 * Math.cos(angle) + 1.78277 * Math.sin(angle))
+    g = fract + amp * (-0.29227 * Math.cos(angle) - 0.90649 * Math.sin(angle))
+    b = fract + amp * (1.97294 * Math.cos(angle))
+
+    [(r * 255).round, (g * 255).round, (b * 255).round]
+  end
+end
+
+class Graphics::Simulation
+  def initialize_rainbow rainbow, name
+    rainbow.cache.each do |degree, color|
+      color_name = "#{name}_#{degree}".to_sym
+      self.register_color(color_name, *color, 255)
+    end
+  end
+end

--- a/test/test_graphics.rb
+++ b/test/test_graphics.rb
@@ -437,6 +437,21 @@ class TestSimulation < Minitest::Test
   # end
 end
 
+require 'graphics/rainbows'
+class TestGraphics < Minitest::Test
+  def setup
+    @t = Graphics::Simulation.new 100, 100, 16, ""
+  end
+
+  def test_registering_rainbows
+    spectrum = Graphics::Hue.new
+    @t.initialize_rainbow spectrum, "spectrum"
+    assert_equal @t.color[:red], @t.color[:spectrum_0]
+    assert_equal @t.color[:green], @t.color[:spectrum_120]
+    assert_equal @t.color[:blue], @t.color[:spectrum_240]
+  end
+end
+
 # class TestTrail < Minitest::Test
 #   def test_draw
 #     raise NotImplementedError, 'Need to write test_draw'

--- a/test/test_rainbows.rb
+++ b/test/test_rainbows.rb
@@ -1,0 +1,95 @@
+require 'minitest/autorun'
+require 'graphics'
+require 'graphics/rainbows'
+
+class RainbowsTest < Minitest::Test
+
+  def setup
+    @greyscale = Graphics::Greyscale.new
+    @hue = Graphics::Hue.new
+    @cubehelix = Graphics::Cubehelix.new
+  end
+
+  def test_clamping
+    assert_equal 360, @hue.clamp(10000, 0, 360)
+    assert_equal 0,   @hue.clamp(-20, 0, 360)
+  end
+
+  def test_scaling_clamps_values
+    assert_equal 360, @hue.scale(10000, 0, 360)
+    assert_equal 0,   @hue.scale(-20, 0, 360)
+  end
+
+  def test_scaling
+    # (We use assert_same instead of _equal to make sure we're
+    # really getting integers back)
+    assert_same 0,   @hue.scale(0, 0, 360)
+    assert_same 180, @hue.scale(180, 0, 360)
+    assert_same 360, @hue.scale(360, 0, 360)
+    assert_same 30,  @hue.scale(30, 0, 360)
+    # From smaller ranges
+    assert_same 0,   @hue.scale(0, 180, 360)
+    assert_same 180, @hue.scale(50, 0, 100)
+    # From larger ranges
+    assert_same 180, @hue.scale(400, 100, 900)
+  end
+
+  def test_greyscale
+    assert_equal [0, 0, 0],       @greyscale.color(0)# Black
+    assert_equal [127, 127, 127], @greyscale.color(180) # Mid-grey
+    assert_equal [255, 255, 255], @greyscale.color(360) # White
+  end
+
+  def test_rainbow_start_and_end
+    # Half a greyscale spectrum
+    assert_equal [127, 127, 127], @greyscale.color(50, 0, 100)
+    assert_equal [255, 255, 255], @greyscale.color(1000, 0, 100)
+  end
+
+  def test_hue
+    assert_equal [255, 0, 0],   @hue.color(0)   # Red
+    assert_equal [255, 127, 0], @hue.color(30)  # Orange
+    assert_equal [255, 255, 0], @hue.color(60)  # Yellow
+    assert_equal [0, 255, 0],   @hue.color(120) # Green
+    assert_equal [0, 255, 255], @hue.color(180) # Cyan
+    assert_equal [0, 0, 255],   @hue.color(240) # Blue
+    assert_equal [255, 0, 255], @hue.color(300) # Magenta
+    assert_equal [255, 0, 0],   @hue.color(360) # Red
+  end
+
+  def test_cubehelix
+    # Cubehelix reference values from James Davenport's Python implementation
+    # Using:
+    # start       = 0.5
+    # rotations   = -1.5
+    # saturation  = 1.2
+    # gamma       = 1.0
+    # NOTE(Lito): These values are slightly different from my Ruby
+    # implementation. This could be floating-point error, or because
+    # cubehelix uses a slightly different scale (1-256 vs 0-360).
+    reference_values = [[0.0, 0.0, 0.0],                              # 0
+    [0.052086060929534689, 0.34174526961141383, 0.30658807547214501], # 90
+    [0.65901854013946559, 0.46936557468373608, 0.24845035363356044],  # 180
+    [0.78295958648052344, 0.69774239781785263, 0.96714049479106534],  # 270
+    [1.0, 1.0, 1.0]]                                                  # 360
+    # Move the colors from 0-1 scale to a 0-255 scale
+    rgb_255_reference = reference_values.map do |rgb|
+      rgb.map do |color|
+        (color*255).round
+      end
+    end
+
+    def assert_arr_in_delta exp, act, delta
+      exp.zip(act) do |e, a|
+        assert_in_delta e, a, delta
+      end
+    end
+
+    assert_arr_in_delta rgb_255_reference[0], @cubehelix.color(0),   2
+    assert_arr_in_delta rgb_255_reference[1], @cubehelix.color(90),  2
+    assert_arr_in_delta rgb_255_reference[2], @cubehelix.color(180), 2
+    assert_arr_in_delta rgb_255_reference[3], @cubehelix.color(270), 2
+    assert_arr_in_delta rgb_255_reference[4], @cubehelix.color(360), 2
+
+  end
+end


### PR DESCRIPTION
This commit contains `graphics/rainbows`, which adds three gradients to `graphics`: `Graphics::Greyscale`, `Graphics::Hue`, and `Graphics::Cubehelix`.
- Greyscale is exactly what it sounds like.
- Hue is the RGB spectrum – what you'd see around the outside of the OSX color picker.
- [Cubehelix](http://www.ifweassume.com/2013/05/cubehelix-or-how-i-learned-to-love.html) is great for visualizations – it's a rainbow that increases in brightness perceptually,
  and indicates 'highs' and 'lows' much better than plain RGB.

``` ruby
require 'graphics'
require 'graphics/rainbows'

# Can add a full rainbow to a Simulation's `color` hash, and name it
my_sim = Graphics::Simulation.new 100, 100, 16, ""
gradient = Graphics::Hue.new
my_sim.initialize_rainbow gradient, "rgb_gradient"
assert(my_sim.color[:rgb_gradient_120] == my_sim.color[:green]) # => true

# Also, can fetch colors as [r,g,b] straight from the rainbow
boring_greyscale = Greyscale.new
middle_grey = boring_greyscale.color(180) # => [127, 127, 127]

# Use those to register specific colors
my_sim.register_color :a_very_drab_grey, *middle_grey

# If you're working with a not-0-to-360 range of values, provide a min and max to #color
still_middle_grey = boring_greyscale.color(90, 0, 180) # => [127, 127, 127]
```
