### PR TITLE
Tweak to clipping to account for movement beyond screen walls.

### DIFF
--- a/lib/graphics/body.rb
+++ b/lib/graphics/body.rb
@@ -177,18 +177,18 @@ class Graphics::Body
     max_h, max_w = w.h, w.w
 
     if x < 0 then
-      self.x = 0
+      self.x = x.abs
       return :west
     elsif x > max_w then
-      self.x = max_w
+      self.x = 2 * max_w - x
       return :east
     end
 
     if y < 0 then
-      self.y = 0
+      self.y = y.abs
       return :south
     elsif y > max_h then
-      self.y = max_h
+      self.y = 2 * max_h - y
       return :north
     end
 

--- a/test/test_graphics.rb
+++ b/test/test_graphics.rb
@@ -105,16 +105,56 @@ class TestBody < Minitest::Test
     assert_in_delta 45, b.m_a[1]
   end
 
-  def test_bounce
+  def test_bounce_east
     b.x = 99
     b.a = 45
 
-    assert_body  99,  50,     10,  45, 0, b
+    assert_body  99,  50, 10, 45, 0, b
+
+    # dist_to_wall_x = w.w - b.x             :: 1
+    # m_over_xy = b.m / Math.sqrt(2)         :: 7.0710678
+    # bounce_x = m_over_xy - dist_to_wall_x  :: 6.0710678
 
     b.move
     b.bounce
 
-    assert_body  100, w.h-42.929,  8, 135, 0, b
+    assert_body w.w-6.07106, 57.07106, 8, 135, 0, b
+  end
+
+  def test_bounce_west
+    b.x = 1
+    b.a = 135
+
+    assert_body  1,  50, 10, 135, 0, b
+
+    b.move
+    b.bounce
+
+    assert_body 6.07106, w.h-42.929, 8, 45, 0, b
+  end
+
+  def test_bounce_north
+    b.y = 99
+    b.a = 45
+
+    assert_body  50,  99, 10, 45, 0, b
+
+    b.move
+    b.bounce
+
+    assert_body 57.071, w.h-6.071, 8, 315, 0, b
+  end
+
+  def test_bounce_south
+    b.y = 1
+    b.a = 315
+
+    assert_body  50, 1, 10, 315, 0, b
+
+    b.move
+    b.bounce
+
+    assert_body 57.071, 6.071, 8, 45, 0, b
   end
 
   def test_clip
@@ -125,7 +165,7 @@ class TestBody < Minitest::Test
     b.move
     b.clip
 
-    assert_body 100, 50, 10, 0, 0, b
+    assert_body 91, 50, 10, 0, 0, b
   end
 
   def test_clip_off_wall
@@ -137,7 +177,7 @@ class TestBody < Minitest::Test
     b.move
     b.clip_off_wall
 
-    assert_body 100, 50, 10, 0, 186, b
+    assert_body 91, 50, 10, 0, 186, b
   end
 
   def test_move


### PR DESCRIPTION
This is not a critical idea, just a tweak. It may be ignored until it proves to be a real problem for simulations.

The problem: a ball under constant force (like gravity) and no friction will constantly accelerate/decelerate.Instead, a ball left to fall with initial speed 0, under grav, without friction, should bounce and reach the same height every time (or reach the floor with the same `m`).

![untitled](https://cloud.githubusercontent.com/assets/584976/12011400/c3be47b4-ac7f-11e5-9bc2-4220b3744365.png)

The ball starts at t_0, at rest under gravity.

After a tick of the clock, it will advance `m` and end beyond the floor at t_2

In reality it should finish at t_1, because it should travel the distance from t_0 to t_3 and then the remaining segment from t_3 to t_2, but as a bounce, which leaves the ball at t_1.

Before, the code was ignoring that extra distance traveled and clipping the ball to the wall (t_3). This patch only takes it into account. 

We have 2 potential solution tweaks:
- Don't add the gravity if in the next tick of the clock the ball will end up out of the screen. (This means changing the code of every force that may be affected).
- Change the ending position of the Ball (this patch).

I think the second approach is more general so it works for all forces, and it is more consisten with how things work in reality. The downside is that it doesn't really clip but bounce.
