### PR TITLE
Add minitest-focus to development dependencies.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,8 @@ Hoe.spec "graphics" do
 
   dependency "rsdl", "~> 0.1"
 
+  extra_dev_deps << ['minitest-focus']
+
   base = "/data/www/docs.seattlerb.org"
   rdoc_locations << "docs-push.seattlerb.org:#{base}/#{remote_rdoc_dir}"
 end


### PR DESCRIPTION
This was necessary to get the tests to run on a fresh checkout.
