### PR TITLE
Fix tests and examples on Ubuntu

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,8 @@ Hoe.spec "graphics" do
 
   dependency "rsdl", "~> 0.1"
 
+  extra_dev_deps << ['minitest-focus']
+
   base = "/data/www/docs.seattlerb.org"
   rdoc_locations << "docs-push.seattlerb.org:#{base}/#{remote_rdoc_dir}"
 end

--- a/examples/canvas.rb
+++ b/examples/canvas.rb
@@ -12,8 +12,8 @@ class Demo < Graphics::Simulation
   def initialize
     super 801, 801
 
-    self.font = find_font("Menlo", 16)
-    self.menlo32 = find_font("Menlo", 32)
+    self.font = find_font(DEFAULT_FONT, 16)
+    self.menlo32 = find_font(DEFAULT_FONT, 32)
 
     self.woot = render_text "woot", :black, menlo32
 

--- a/examples/canvas.rb
+++ b/examples/canvas.rb
@@ -6,16 +6,16 @@ require "graphics"
 class Demo < Graphics::Simulation
   CLEAR_COLOR = :white
 
-  attr_accessor :woot, :menlo32
+  attr_accessor :woot, :big_font
   attr_accessor :rct
 
   def initialize
     super 801, 801
 
     self.font = find_font(DEFAULT_FONT, 16)
-    self.menlo32 = find_font(DEFAULT_FONT, 32)
+    self.big_font = find_font(DEFAULT_FONT, 32)
 
-    self.woot = render_text "woot", :black, menlo32
+    self.woot = render_text "woot", :black, big_font
 
     self.rct = sprite 50, 25 do
       rect 0, 0, 49, 24, :blue # TODO: can't be black?!?
@@ -35,7 +35,7 @@ class Demo < Graphics::Simulation
       shift = (woot.h*Math.sin(D2R*deg))
       put woot, 400-shift, 300, deg
     end
-    text "woot", 400, 300, :red, menlo32
+    text "woot", 400, 300, :red, big_font
 
     rect 550, 100, 50, 50, :blue, :filled
     rect 575, 125, 50, 50, :blue

--- a/lib/graphics/simulation.rb
+++ b/lib/graphics/simulation.rb
@@ -21,6 +21,12 @@ class Graphics::AbstractSimulation
   # Call +log+ every N ticks, if +log+ is defined.
   LOG_INTERVAL = 60
 
+  # The default font. Menlo on OS X, Deja Vu Sans Mono on linux.
+  DEFAULT_FONT =  case RUBY_PLATFORM
+                  when /darwin/ ; 'Menlo'
+                  when /linux/  ; 'DejaVuSansMono'
+                  end
+
   # Collection of collections of Bodies to auto-update and draw.
   attr_accessor :_bodies
 
@@ -68,7 +74,7 @@ class Graphics::AbstractSimulation
 
     self._bodies = []
 
-    self.font = find_font("Menlo", 32)
+    self.font = find_font(DEFAULT_FONT, 32)
 
     SDL::WM.set_caption name, name
 
@@ -118,10 +124,16 @@ class Graphics::AbstractSimulation
     end
   end
 
-  sys_font  = "/System/Library/Fonts"
-  lib_font  = "/Library/Fonts"
-  user_font = File.expand_path "~/Library/Fonts/"
-  FONT_GLOB = "{#{sys_font},#{lib_font},#{user_font}}" # :nodoc:
+  font_dirs = [
+    # OS X
+    "/System/Library/Fonts",
+    "/Library/Fonts",
+    File.expand_path("~/Library/Fonts/"),
+
+    # Ubuntu
+    "/usr/share/fonts/truetype/**/",
+  ]
+  FONT_GLOB = "{#{font_dirs.join(",")}}" # :nodoc:
 
   ##
   # Find and open a (TTF) font. Should be as system agnostic as possible.


### PR DESCRIPTION
This includes the one commit from #15 necessary for running tests.

With these changes I can run the tests successfully and the `boid` and `canvas` examples.

![demo_810](https://cloud.githubusercontent.com/assets/22962/12411883/e2c9c9c6-be36-11e5-87ff-b07f72782c65.png)
