### PR TITLE
Adding missing files to manifest for rainbows

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -59,7 +59,9 @@ ext/sdl/sge/sge_tt_text.h
 graphics_setup.sh
 lib/graphics.rb
 lib/graphics/body.rb
+lib/graphics/decorators.rb
 lib/graphics/extensions.rb
+lib/graphics/rainbows.rb
 lib/graphics/simulation.rb
 lib/graphics/trail.rb
 lib/graphics/v.rb


### PR DESCRIPTION
I wasn't able to use rainbows with default install of graphics gem - I believe these were missing from Manifest. Let me know if this is the right way to fix!
