### PR TITLE
Broader search for fonts on Linux

### DIFF
--- a/lib/graphics/simulation.rb
+++ b/lib/graphics/simulation.rb
@@ -161,7 +161,7 @@ class Graphics::AbstractSimulation
     File.expand_path("~/Library/Fonts/"),
 
     # Ubuntu
-    "/usr/share/fonts/truetype/**/",
+    "/usr/share/fonts/**/",
   ]
   FONT_GLOB = "{#{font_dirs.join(",")}}" # :nodoc:
 


### PR DESCRIPTION
On my system there are all kinds of wacky subdirectories in `/usr/share/fonts`. `DejaVuSansMono.ttf` happens to be in `/usr/share/fonts/TTF` not `/usr/share/fonts/truetype`. Since the code searches by `ttf`/`ttc` extensions I suggest it's fine to have a broader search.