### PR TITLE
Reorder installation instructions & format as code

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -86,8 +86,8 @@ up-to-date versions.
 
 == INSTALL:
 
-* sudo gem install graphics
-* `curl -L https://tinyurl.com/graphics-setup | bash`
+    curl -L https://tinyurl.com/graphics-setup | bash
+    sudo gem install graphics
 
 == LICENSE:
 


### PR DESCRIPTION
- Moved package manager dependency install script ahead of gem installation
- Formatted both commands as code for readability and easier copy pasting