### PR TITLE
Add basic package manager detection to deps script

### DIFF
--- a/graphics_setup.sh
+++ b/graphics_setup.sh
@@ -2,39 +2,48 @@
 
 set -v
 
-case `uname` in
+case "$(uname -s)" in
     Darwin)
-	echo "I'm on OSX. Not using sudo"
-	SUDO=
+        if command -v brew >/dev/null; then
+	    echo "Detected macOS. Installing dependencies with brew."
+	    sudo=""
 
-	brew install sdl2
-	brew install sdl2_mixer
-	brew install sdl2_ttf
-	brew install sdl2_image
-	brew install sdl2_gfx
+	    brew install sdl2
+	    brew install sdl2_mixer
+	    brew install sdl2_ttf
+	    brew install sdl2_image
+	    brew install sdl2_gfx
+        else
+            echo "Detected macOS but not brew. Install Homebrew and try again."
+            exit 1
+        fi
 	;;
     Linux)
-	echo "I'm on linux, using sudo where needed"
-	SUDO=sudo
+        if command -v apt >/dev/null; then
+            echo "Detected Linux. Installing dependencies with apt."
+            sudo="sudo"
 
-	$SUDO apt-get install --no-install-recommends --no-install-suggests libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev gcc g++
-	;;
+            $sudo apt-get install --no-install-recommends --no-install-suggests libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev gcc g++
+        else
+            echo "Detected macOS but not apt. Install sdl2 with your package manager."
+            exit 1
+        fi
+        ;;
     *)
-	echo "Unknown OS $OSTYPE, aborting"
-	exit 1
+        echo "Dependency installation not supported for your OS. Install sdl2 with your package manager."
+        exit 1
 	;;
 esac
 
-if [ -f $0 ]; then
-    $SUDO gem update --system -N -V
-    $SUDO gem install hoe --conservative
-    $SUDO rake newb
+if [ -f "$0" ]; then
+    $sudo gem install hoe --conservative
+    $sudo rake newb
     rake test
     rake clean package
-    $SUDO gem install pkg/graphics*.gem
+    $sudo gem install pkg/graphics*.gem
 else
-    $SUDO gem install graphics
+    $sudo gem install graphics
 fi
 
-echo "running a test... you should see a window show up."
+echo "Running a graphics test... You should see a window appear."
 ruby -Ilib -rgraphics -e 'Class.new(Graphics::Simulation) { def draw n; clear :white; text "hit escape to quit", 100, 100, :black; end; }.new(500, 250, "Working!").run'


### PR DESCRIPTION
- Detect `apt` and `brew` command presence and give appropriate messages if missing.
- Dropped `$OSTYPE` since `foo-bar` seems potentially more confusing than helpful and folk should know their OS already.
- Dropped `sudo gem update --system` since macOS and Debian sudo Rubies may refuse and it's not a mandatory step.
- Minor `shellscript` changes like using `$()` over backticks and quoting to prevent globbing and word splitting.
- Inconsequentially switching `$SUDO` to `$sudo` by convention since it's not exported.